### PR TITLE
Mark0129

### DIFF
--- a/8020GCodeGen.html
+++ b/8020GCodeGen.html
@@ -172,6 +172,7 @@ var allowedSubstitutions = {
     "DrillCannedOpGC" : [ "StockHeight", "RapidToZ", "SafeRetractZ" ],
     "CenterdrillCannedStartGC" : [ "FeedRate", "SafeRetractZ" ],
     "CenterdrillOpGC" : [ "StockHeight", "RapidToZ", "CenterdrillDepth" ],
+    "CenterdrillCannedOpGC" : [ "StockHeight", "RapidToZ", "CenterdrillDepth" ],
     "CounterboredDrillCannedStartGC" : [ "FeedRate", "SafeRetractZ" ],
     "CounterboredDrillCannedOpGC" : [ "StockHeight", "RapidToZ", "SafeRetractZ" ],
     "CounterboredCenterdrillCannedStartGC" : [ "FeedRate", "SafeRetractZ" ],
@@ -251,6 +252,11 @@ function parseHoleDesc() {
     params["StockLength"] = lines[5];
     params["StockHeight"] = lines[6];
     var v;
+    v = params["HoleType"];
+    if (v != "Counterbore") {
+	alert("Only counterbore hole types are currently allowed");
+	return null;
+    }
     v = params["StockLength"];
     if (!isNumber(v)) {
         alert("Suspicious stock length '" + v + "'");

--- a/8020GCodeGen.html
+++ b/8020GCodeGen.html
@@ -1024,7 +1024,7 @@ function clearGCode() {
 <center>
 <table>
 <tr><td><hr style="width:100%;color:gray;margin-left:0"></td></tr>
-<tr><td><font size=2>Team 293 (SPIKE) G-code generator. Last updated Jan 21, 2023.</font></td></tr>
+<tr><td><font size=2>Team 293 (SPIKE) G-code generator. Last updated <span id=lastUpdated>Jan 21, 2023</span>.</font></td></tr>
 <tr><td><hr style="width:100%;color:gray;margin-left:0"></td></tr>
 </table>
 <label for=machineSelect>Machine:</label>&nbsp;<select id=machineSelect name=machineSelect onchange=updateMachineSelect() disabled></select>
@@ -1127,6 +1127,9 @@ for (var i = 0; i < machine["XOffsets"].length; i++) {
     el.innerHTML += " " + machine["XOffsets"][i];
 }
 el.innerHTML += "</b>";
+// Update the modification time
+el = getEl("lastUpdated");
+el.innerHTML = new Date(document.lastModified).toLocaleString();
 </script>
 
 </body>


### PR DESCRIPTION
Found that some folks were trying to do simple through drills instead of counterbored holes and the canned op gcode wasn't getting generated correctly. (No entry in AllowedSubstitutions.) While we aren't currently supposed to be using simple drills anyway, otherwise the code does support it, so went ahead and fixed that. Since we aren't supposed to be using that feature currently, I've also added an alert (and error) if the HoleType is not Counterbore. Also added a span to contain the last modified date for the file and have it updated automatically.